### PR TITLE
chore: update deployment probes based on configuration settings

### DIFF
--- a/charts/ryze/Chart.yaml
+++ b/charts/ryze/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ryze/templates/deployment.yaml
+++ b/charts/ryze/templates/deployment.yaml
@@ -44,12 +44,15 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          startupProbe:
-            {{- toYaml .Values.startupProbe | nindent 12 }}
-          livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
-          readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe: {{- omit .Values.startupProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe: {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/ryze/values.yaml
+++ b/charts/ryze/values.yaml
@@ -72,6 +72,7 @@ resources: {}
   #   memory: 128Mi
 
 startupProbe:
+  enabled: true
   httpGet:
     path: /api/healthz
     port: http
@@ -81,6 +82,7 @@ startupProbe:
   successThreshold: 1
   failureThreshold: 36
 livenessProbe:
+  enabled: true
   httpGet:
     path: /api/healthz
     port: http
@@ -90,6 +92,7 @@ livenessProbe:
   successThreshold: 1
   failureThreshold: 1
 readinessProbe:
+  enabled: true
   httpGet:
     path: /api/healthz
     port: http


### PR DESCRIPTION
- Update the version number in `Chart.yaml` from `0.1.0` to `0.1.1`
- Modify the `deployment.yaml` template to conditionally include probe configurations based on their `enabled` status in `values.yaml`
- Enable the `startupProbe`, `livenessProbe`, and `readinessProbe` in `values.yaml` by setting `enabled` to `true`